### PR TITLE
Add migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Install
 git clone https://github.com/TheBlackArroVV/super_karma_bot
 cp .env.example .env
 bundle install
+rake db:migrate
 bundle exec ruby main.rb
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,13 @@
+namespace :db do
+  desc 'Run migrations'
+  task :migrate, [:version] do |_t, args|
+    require 'sequel/core'
+    require 'dotenv/load'
+
+    Sequel.extension :migration
+    version = args[:version].to_i if args[:version]
+    Sequel.connect(ENV.fetch('DATABASE_URL')) do |db|
+      Sequel::Migrator.run(db, 'db/migrations', target: version)
+    end
+  end
+end

--- a/db/database.rb
+++ b/db/database.rb
@@ -2,7 +2,9 @@ require 'sequel'
 
 class Database
   def initialize
-    initialize_db
+    @db = Sequel.connect(DATABASE_URL)
+
+    @users = @db[:users]
   end
 
   def increase_karma(user_name)
@@ -33,23 +35,5 @@ class Database
     users
       .to_a
       .group_by { |user| user[:count] }
-  end
-
-  private
-
-  def initialize_db
-    @db = Sequel.connect(DATABASE_URL)
-
-    initialize_table
-
-    @users = @db[:users]
-  end
-
-  def initialize_table
-    @db.create_table? :users do
-      primary_key :id
-      String :user_name
-      Integer :count
-    end
   end
 end

--- a/db/migrations/1_create_users.rb
+++ b/db/migrations/1_create_users.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    create_table? :users do
+      primary_key :id
+      String :user_name
+      Integer :count
+    end
+  end
+end

--- a/db/migrations/2_add_user_info_to_users.rb
+++ b/db/migrations/2_add_user_info_to_users.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    add_column :users, :first_name, String
+    add_column :users, :last_name, String
+    add_column :users, :telegram_id, Integer
+  end
+end

--- a/db/migrations/3_add_index_to_users.rb
+++ b/db/migrations/3_add_index_to_users.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:users) do
+      add_index :user_name, unique: true
+    end
+  end
+end


### PR DESCRIPTION
After merging this PR we are able to use `Sequel` [migrations](https://github.com/jeremyevans/sequel/blob/master/doc/migration.rdoc) for changing DB.

Was added `Rakefile`, for made migration easily.

Was added `index` for `user_name` to `users` DB.

Before running migration needs to create a backup:

1. ```heroku pg:backups:capture```
1. ```heroku pg:backups:download```

After deploying this PR, need to run

```rake db:migrate```